### PR TITLE
Fix typo in initial method name

### DIFF
--- a/js/bruh-dash.js
+++ b/js/bruh-dash.js
@@ -26,14 +26,14 @@ global.bruhdash = {
   },
 
   first: function () {
-      
+
   },
 
   indexOf: function () {
 
   },
 
-  inital: function () {
+  initial: function () {
 
   },
 


### PR DESCRIPTION
This method had a typo in it's name.
