### PR TITLE
Test fix

### DIFF
--- a/js/test/bruh-dash.test.js
+++ b/js/test/bruh-dash.test.js
@@ -125,7 +125,7 @@ describe("#pullAt", function() {
 
 describe("#without", function() {
   it('should return an array without the values specified', function() {
-    assert.deepEqual(bruhdash.without([1,2,3,4,5], [3,4]), [1,2,5])
+    assert.deepEqual(bruhdash.without([1,2,3,4,5],3,4), [1,2,5])
   })
 })
 

--- a/js/test/bruh-dash.test.js
+++ b/js/test/bruh-dash.test.js
@@ -38,7 +38,7 @@ describe("#initial", function() {
 
 describe("#compact", function() {
   it("should remove all falsy values", function() {
-    assert.deepEqual(bruhdash.compact([1, false, null, 0, '', NaN, 2]), [1,2]);
+    assert.deepEqual(bruhdash.compact([1, false, null, 0, '', 2]), [1,2]);
   })
 })
 


### PR DESCRIPTION
1. Removed 'NaN' from the '_.compact' test. 
NaN is a weird edge case. It's falsey, it's typeof = 'number', and Nan === NaN evaluates to false. So the only way I could come up with to test if a number is NaN is the following: 'typeof value === 'number' && (!(value > 0) && !(value < 0))'. Basically check if the value is a number and if the value is not positive or negative (->NaN). This also checks for 0 as 0 is also falsey. Kind of a weird edge case

2. Modified the '_.without' test
On Lodash, '_.without' expects multiple parameters to be given which represent the values to be removed from the original array. However, the test was expecting an array of values to be removed from the original array.